### PR TITLE
add missing pinMode to OttoMatrix

### DIFF
--- a/Otto_Matrix9/Otto_Matrix9.cpp
+++ b/Otto_Matrix9/Otto_Matrix9.cpp
@@ -39,6 +39,7 @@ void Otto_Matrix::init(byte _data, byte _load, byte _clock, byte _num, int _rota
 #else
     pinMode(data,  OUTPUT);
     pinMode(clock, OUTPUT);
+    pinMode(load,  OUTPUT);
     digitalWrite(clock, HIGH); 
 #endif
 


### PR DESCRIPTION
I lost my matrix display after having updated my Otto to the App V9 sketch.
Comparing my old library with this, I found it missing the setup of the load pin.